### PR TITLE
Use a throwaway secret to webhook exchanges

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	"gopkg.in/telegram-bot-api.v4"
+	tgbotapi "gopkg.in/telegram-bot-api.v4"
 )
 
 func handleTelegramWebhook(w http.ResponseWriter, r *http.Request) {
@@ -29,4 +30,9 @@ func handleTelegramWebhook(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unknown body", http.StatusBadRequest)
 		return
 	}
+}
+
+func registerTelegramWebhook() error {
+	_, err := BotAPI.SetWebhook(tgbotapi.NewWebhook(fmt.Sprintf("https://%s/telegram/webhook/%s", Configuration.Hostname, Secrets.WebhookSecret)))
+	return err
 }

--- a/server/random.go
+++ b/server/random.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+func GenerateRandomString(n int) (string, error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return "", err
+		}
+		ret[i] = letters[num.Int64()]
+	}
+
+	return string(ret), nil
+}


### PR DESCRIPTION
This should avoid exposing the bot token too much in logs and stuff.

Also, now the webhook is registered on boot.